### PR TITLE
Fix for refresh attachments

### DIFF
--- a/indra/newview/llviewerjointattachment.cpp
+++ b/indra/newview/llviewerjointattachment.cpp
@@ -28,6 +28,9 @@
 
 #include "llviewerjointattachment.h"
 
+// [SL:KB] - Patch: Appearance-PhantomAttach | Checked: Catznip-5.0
+#include "llagent.h"
+// [/SL:KB]
 #include "llviewercontrol.h"
 #include "lldrawable.h"
 #include "llgl.h"
@@ -164,7 +167,7 @@ void LLViewerJointAttachment::setupDrawable(LLViewerObject *object)
 //-----------------------------------------------------------------------------
 bool LLViewerJointAttachment::addObject(LLViewerObject* object)
 {
-    object->extractAttachmentItemID();
+//     object->extractAttachmentItemID();
 
     // Same object reattached
     if (isObjectAttached(object))
@@ -175,17 +178,39 @@ bool LLViewerJointAttachment::addObject(LLViewerObject* object)
         // re-connect object to the joint correctly
     }
 
+// [SL:KB] - Patch: Appearance-Misc | Checked: 2011-01-13 (Catznip-2.4)
+    // LLViewerJointAttachment::removeObject() sets the object's item to the NULL UUID so we need to extract it *after* the block above
+    object->extractAttachmentItemID();
+// [/SL:KB]
+
     // Two instances of the same inventory item attached --
     // Request detach, and kill the object in the meantime.
-    if (getAttachedObject(object->getAttachmentItemID()))
+// [SL:KB] - Patch: Appearance-PhantomAttach | Checked: Catznip-5.0
+    if (LLViewerObject* pAttachObj = getAttachedObject(object->getAttachmentItemID()))
     {
         LL_INFOS() << "(same object re-attached)" << LL_ENDL;
-        object->markDead();
-
-        // If this happens to be attached to self, then detach.
-        LLVOAvatarSelf::detachAttachmentIntoInventory(object->getAttachmentItemID());
-        return false;
+        pAttachObj->markDead();
+        if (pAttachObj->permYouOwner())
+        {
+            gMessageSystem->newMessage("ObjectDetach");
+            gMessageSystem->nextBlockFast(_PREHASH_AgentData);
+            gMessageSystem->addUUIDFast(_PREHASH_AgentID, gAgent.getID());
+            gMessageSystem->addUUIDFast(_PREHASH_SessionID, gAgent.getSessionID());
+            gMessageSystem->nextBlockFast(_PREHASH_ObjectData);
+            gMessageSystem->addU32Fast(_PREHASH_ObjectLocalID, pAttachObj->getLocalID());
+            gMessageSystem->sendReliable(gAgent.getRegionHost());
+        }
     }
+// [/SL:KB]
+//     if (getAttachedObject(object->getAttachmentItemID()))
+//     {
+//         LL_INFOS() << "(same object re-attached)" << LL_ENDL;
+//         object->markDead();
+//
+//         // If this happens to be attached to self, then detach.
+//         LLVOAvatarSelf::detachAttachmentIntoInventory(object->getAttachmentItemID());
+//         return FALSE;
+//     }
 
     mAttachedObjects.push_back(object);
     setupDrawable(object);
@@ -457,7 +482,10 @@ const LLViewerObject *LLViewerJointAttachment::getAttachedObject(const LLUUID &o
          ++iter)
     {
         const LLViewerObject* attached_object = iter->get();
-        if (attached_object->getAttachmentItemID() == object_id)
+//         if (attached_object->getAttachmentItemID() == object_id)
+// [SL:KB] - Patch: Appearance-PhantomAttach | Checked: Catznip-5.0
+        if ( (attached_object->getAttachmentItemID() == object_id) && (!attached_object->isDead()) )
+// [/SL:KB]
         {
             return attached_object;
         }


### PR DESCRIPTION
Missing `llviewerjointattachment.cpp` change for refresh attachments to fully function

https://github.com/FirestormViewer/phoenix-firestorm/commit/07ad25c6be898e42e870b1b6db84f6b16b7275f6#diff-c4316b59d0c69a9672ddfb53e2bc9172c30f1f30017a9c7e4ce817c0905e47cbR34