### PR TITLE
Combat features

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -1365,6 +1365,63 @@
       <integer>1</integer>
     </map>
     <!-- End NaCl/Firestorm port -->
+    <!-- OTS over-the-shoulder aim settings -->
+    <key>OTSEnabled</key>
+    <map>
+      <key>Comment</key>
+      <string>When true, M key enters OTS shoulder cam instead of first-person mouselook</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
+    <key>OTSCameraDistance</key>
+    <map>
+      <key>Comment</key>
+      <string>OTS camera distance behind avatar (meters)</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>3.0</real>
+    </map>
+    <key>OTSCameraSide</key>
+    <map>
+      <key>Comment</key>
+      <string>OTS camera side offset (negative = right of avatar)</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>-0.5</real>
+    </map>
+    <key>OTSCameraHeight</key>
+    <map>
+      <key>Comment</key>
+      <string>OTS camera height above avatar root (meters)</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>0.5</real>
+    </map>
+    <key>OTSFocusDistance</key>
+    <map>
+      <key>Comment</key>
+      <string>OTS focus point distance in front of avatar (meters)</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>10.0</real>
+    </map>
+    <!-- End OTS settings -->
     <key>CameraOffset</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -2123,6 +2123,13 @@ std::ostream& operator<<(std::ostream &s, const LLAgent &agent)
 //-----------------------------------------------------------------------------
 bool LLAgent::needsRenderAvatar()
 {
+    // OTS mode: always render avatar — we are in third-person even though
+    // mouselook input is active.
+    if (gAgentCamera.cameraOTS())
+    {
+        return mShowAvatar && mOutfitChosen;
+    }
+
     if (gAgentCamera.cameraMouselook() && !LLVOAvatar::sVisibleInFirstPerson)
     {
         return false;
@@ -2134,6 +2141,11 @@ bool LLAgent::needsRenderAvatar()
 // true if we need to render your own avatar's head.
 bool LLAgent::needsRenderHead()
 {
+    // OTS mode: always render head — avatar is fully visible.
+    if (gAgentCamera.cameraOTS())
+    {
+        return mShowAvatar;
+    }
     return (LLVOAvatar::sVisibleInFirstPerson && LLPipeline::sReflectionRender) || (mShowAvatar && !gAgentCamera.cameraMouselook());
 }
 
@@ -2247,7 +2259,8 @@ void LLAgent::endAnimationUpdateUI()
     }
 
     // clean up UI from mode we're leaving
-    if (gAgentCamera.getLastCameraMode() == CAMERA_MODE_MOUSELOOK )
+    if (gAgentCamera.getLastCameraMode() == CAMERA_MODE_MOUSELOOK
+        || gAgentCamera.getLastCameraMode() == CAMERA_MODE_OTS)
     {
         gToolBarView->setToolBarsVisible(true);
         // show mouse cursor
@@ -2369,7 +2382,8 @@ void LLAgent::endAnimationUpdateUI()
     //---------------------------------------------------------------------
     // Set up UI for mode we're entering
     //---------------------------------------------------------------------
-    if (gAgentCamera.getCameraMode() == CAMERA_MODE_MOUSELOOK)
+    if (gAgentCamera.getCameraMode() == CAMERA_MODE_MOUSELOOK
+        || gAgentCamera.getCameraMode() == CAMERA_MODE_OTS)
     {
         // clean up UI
         // first show anything hidden by UI toggle

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -2297,6 +2297,14 @@ void LLAgentCamera::changeCameraToOTS()
         {
             gAgentAvatarp->updateAttachmentVisibility(CAMERA_MODE_THIRD_PERSON);
         }
+
+        // Start the camera animation LAST, after mCameraMode is OTS and after
+        // changeCameraToMouselook(false) has cleared mCameraAnimating via its
+        // animate=false branch. The rendered camera is still at the old
+        // (third-person) position this frame, so startCameraAnimation snapshots
+        // that as the start point and updateCamera lerps to the OTS shoulder
+        // target over ZoomTime seconds — matching the mouselook transition feel.
+        startCameraAnimation();
     }
 }
 
@@ -2406,7 +2414,7 @@ void LLAgentCamera::changeCameraToThirdPerson(bool animate)
         }
 
         mCameraLag.clearVec();
-        if (mCameraMode == CAMERA_MODE_MOUSELOOK)
+        if (mCameraMode == CAMERA_MODE_MOUSELOOK || mCameraMode == CAMERA_MODE_OTS)
         {
             mCurrentCameraDistance = MIN_CAMERA_DISTANCE;
             mTargetCameraDistance = MIN_CAMERA_DISTANCE;

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -1176,7 +1176,7 @@ void LLAgentCamera::updateLookAt(const S32 mouse_x, const S32 mouse_y)
         LLVector3 headLookAxis;
         LLCoordFrame frameCamera = *((LLCoordFrame*)LLViewerCamera::getInstance());
 
-        if (cameraMouselook())
+        if (cameraMouselook() || cameraOTS())
         {
             lookAtType = LOOKAT_TARGET_MOUSELOOK;
         }
@@ -1409,7 +1409,7 @@ void LLAgentCamera::updateCamera()
             gAgent.setShowAvatar(true);
         }
 
-        if (isAgentAvatarValid() && (mCameraMode != CAMERA_MODE_MOUSELOOK))
+        if (isAgentAvatarValid() && mCameraMode != CAMERA_MODE_MOUSELOOK)
         {
             gAgentAvatarp->updateAttachmentVisibility(mCameraMode);
         }
@@ -1497,7 +1497,8 @@ void LLAgentCamera::updateCamera()
     }
     gAgent.setLastPositionGlobal(global_pos);
 
-    if (LLVOAvatar::sVisibleInFirstPerson && isAgentAvatarValid() && !gAgentAvatarp->isSitting() && cameraMouselook())
+    // Exclude OTS — shoulder camera position must not be overridden by head-tracking.
+    if (LLVOAvatar::sVisibleInFirstPerson && isAgentAvatarValid() && !gAgentAvatarp->isSitting() && cameraMouselook() && !cameraOTS())
     {
         LLVector3 head_pos = gAgentAvatarp->mHeadp->getWorldPosition() +
             LLVector3(0.08f, 0.f, 0.05f) * gAgentAvatarp->mHeadp->getWorldRotation() +
@@ -1596,6 +1597,19 @@ LLVector3d LLAgentCamera::calcFocusPositionTargetGlobal()
     if (mCameraMode == CAMERA_MODE_FOLLOW && mFocusOnAvatar)
     {
         mFocusTargetGlobal = gAgent.getPosGlobalFromAgent(mFollowCam.getSimulatedFocus());
+        return mFocusTargetGlobal;
+    }
+    else if (mCameraMode == CAMERA_MODE_OTS)
+    {
+        // Focus in front of avatar at aim height
+        static LLCachedControl<F32> ots_focus_dist(gSavedSettings, "OTSFocusDistance", 10.0f);
+        static LLCachedControl<F32> ots_height(gSavedSettings,     "OTSCameraHeight",   0.5f);
+        static LLCachedControl<F32> ots_side(gSavedSettings,       "OTSCameraSide",    -0.5f);
+        LLVector3 focus_local((F32)ots_focus_dist, (F32)ots_side * 0.3f, (F32)ots_height * 0.5f);
+        LLQuaternion agent_rot = gAgent.getFrameAgent().getQuaternion();
+        LLVector3 focus_world = focus_local * agent_rot;
+        LLVector3d avatar_pos = gAgent.getPosGlobalFromAgent(getAvatarRootPosition());
+        mFocusTargetGlobal = avatar_pos + LLVector3d(focus_world);
         return mFocusTargetGlobal;
     }
     else if (mCameraMode == CAMERA_MODE_MOUSELOOK)
@@ -1775,6 +1789,18 @@ LLVector3d LLAgentCamera::calcCameraPositionTargetGlobal(bool *hit_limit)
     if (mCameraMode == CAMERA_MODE_FOLLOW && mFocusOnAvatar)
     {
         camera_position_global = gAgent.getPosGlobalFromAgent(mFollowCam.getSimulatedPosition());
+    }
+    else if (mCameraMode == CAMERA_MODE_OTS)
+    {
+        // Shoulder offset camera — avatar-local space: X=forward, Y=left, Z=up
+        static LLCachedControl<F32> ots_dist(gSavedSettings,   "OTSCameraDistance", 3.0f);
+        static LLCachedControl<F32> ots_side(gSavedSettings,   "OTSCameraSide",    -0.5f);
+        static LLCachedControl<F32> ots_height(gSavedSettings, "OTSCameraHeight",   0.5f);
+        LLVector3 local_offset(-(F32)ots_dist, (F32)ots_side, (F32)ots_height);
+        LLQuaternion agent_rot = gAgent.getFrameAgent().getQuaternion();
+        LLVector3 world_offset = local_offset * agent_rot;
+        LLVector3d avatar_pos = gAgent.getPosGlobalFromAgent(getAvatarRootPosition());
+        camera_position_global = avatar_pos + LLVector3d(world_offset);
     }
     else if (mCameraMode == CAMERA_MODE_MOUSELOOK)
     {
@@ -2242,6 +2268,50 @@ void LLAgentCamera::changeCameraToDefault()
     }
 }
 
+
+//-----------------------------------------------------------------------------
+// changeCameraToOTS()
+// Over-the-shoulder aim mode.
+// Calls changeCameraToMouselook() to inherit ALL of its input setup
+// (cursor hiding, mouse capture, control flags, focus management),
+// then immediately overrides mCameraMode to CAMERA_MODE_OTS so that
+// calcCameraPositionTargetGlobal places the camera at the shoulder offset
+// instead of the avatar's eye position.
+// Avatar rendering is handled explicitly in needsRenderAvatar() and needsRenderHead().
+//-----------------------------------------------------------------------------
+void LLAgentCamera::changeCameraToOTS()
+{
+    if (mCameraMode != CAMERA_MODE_OTS)
+    {
+        // Inherit everything from mouselook: cursor lock, mouse capture,
+        // AGENT_CONTROL_MOUSELOOK flag, keyboard focus clear, etc.
+        changeCameraToMouselook(false);
+
+        // Override mCameraMode to OTS so position/focus calculations
+        // use the shoulder offset instead of the eye position.
+        mCameraMode = CAMERA_MODE_OTS;
+
+        // changeCameraToMouselook hid attachments via updateAttachmentVisibility
+        // with CAMERA_MODE_MOUSELOOK. Restore full visibility for OTS mode.
+        if (isAgentAvatarValid())
+        {
+            gAgentAvatarp->updateAttachmentVisibility(CAMERA_MODE_THIRD_PERSON);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// changeCameraFromOTS()
+//-----------------------------------------------------------------------------
+void LLAgentCamera::changeCameraFromOTS()
+{
+    if (mCameraMode == CAMERA_MODE_OTS)
+    {
+        // changeCameraToDefault handles clearing AGENT_CONTROL_MOUSELOOK,
+        // showing the cursor, and restoring the normal camera mode.
+        changeCameraToDefault();
+    }
+}
 
 //-----------------------------------------------------------------------------
 // changeCameraToFollow()

--- a/indra/newview/llagentcamera.h
+++ b/indra/newview/llagentcamera.h
@@ -43,7 +43,8 @@ enum ECameraMode
     CAMERA_MODE_THIRD_PERSON,
     CAMERA_MODE_MOUSELOOK,
     CAMERA_MODE_CUSTOMIZE_AVATAR,
-    CAMERA_MODE_FOLLOW
+    CAMERA_MODE_FOLLOW,
+    CAMERA_MODE_OTS          // Over-the-shoulder: mouselook input + third-person camera
 };
 
 /** Camera Presets for CAMERA_MODE_THIRD_PERSON */
@@ -93,10 +94,14 @@ public:
     void            changeCameraToThirdPerson(bool animate = true);
     void            changeCameraToCustomizeAvatar(); // Trigger transition animation
     void            changeCameraToFollow(bool animate = true);  // Ventrella
+    void            changeCameraToOTS();             // Over-the-shoulder aim mode
+    void            changeCameraFromOTS();           // Exit OTS back to third person
     bool            cameraThirdPerson() const       { return (mCameraMode == CAMERA_MODE_THIRD_PERSON && mLastCameraMode == CAMERA_MODE_THIRD_PERSON); }
-    bool            cameraMouselook() const         { return (mCameraMode == CAMERA_MODE_MOUSELOOK && mLastCameraMode == CAMERA_MODE_MOUSELOOK); }
+    // Also true for OTS — reuses mouselook input and UI behaviour; camera position handled separately.
+    bool            cameraMouselook() const         { return (mCameraMode == CAMERA_MODE_MOUSELOOK && mLastCameraMode == CAMERA_MODE_MOUSELOOK) || mCameraMode == CAMERA_MODE_OTS; }
     bool            cameraCustomizeAvatar() const   { return (mCameraMode == CAMERA_MODE_CUSTOMIZE_AVATAR /*&& !mCameraAnimating*/); }
     bool            cameraFollow() const            { return (mCameraMode == CAMERA_MODE_FOLLOW && mLastCameraMode == CAMERA_MODE_FOLLOW); }
+    bool            cameraOTS() const               { return mCameraMode == CAMERA_MODE_OTS; }
     ECameraMode     getCameraMode() const           { return mCameraMode; }
     ECameraMode     getLastCameraMode() const       { return mLastCameraMode; }
     void            updateCamera();                 // Call once per frame to update camera location/orientation

--- a/indra/newview/llquickprefs.cpp
+++ b/indra/newview/llquickprefs.cpp
@@ -26,6 +26,8 @@
 #include "llquickprefs.h"
 
 #include "llagent.h"
+#include "llagentcamera.h"
+#include "llcheckboxctrl.h"
 #include "llsliderctrl.h"
 #include "lltextbox.h"
 #include "llviewercontrol.h"
@@ -96,6 +98,14 @@ bool LLFloaterQuickPrefs::postBuild()
             boost::bind(&LLFloaterQuickPrefs::onRegionChanged, this));
     }
     onRegionChanged();  // evaluate current region immediately
+
+    // OTS aim mode checkbox
+    mOTSEnabledCheck = getChild<LLCheckBoxCtrl>("ots_enabled");
+    if (mOTSEnabledCheck)
+    {
+        mOTSEnabledCheck->setCommitCallback(
+            boost::bind(&LLFloaterQuickPrefs::onOTSEnabledChanged, this));
+    }
 
     return true;
 }
@@ -202,4 +212,17 @@ void LLFloaterQuickPrefs::syncAvatarZOffsetFromPreferenceSetting()
 {
     F32 value = gSavedPerAccountSettings.getF32("AvatarHoverOffsetZ");
     mAvatarZOffsetSlider->setValue(value, false);   // false = no commit signal
+}
+
+void LLFloaterQuickPrefs::onOTSEnabledChanged()
+{
+    if (mOTSEnabledCheck)
+    {
+        gSavedSettings.setBOOL("OTSEnabled", mOTSEnabledCheck->get());
+        // If currently in OTS mode and checkbox was unchecked, exit OTS
+        if (!mOTSEnabledCheck->get() && gAgentCamera.cameraOTS())
+        {
+            gAgentCamera.changeCameraFromOTS();
+        }
+    }
 }

--- a/indra/newview/llquickprefs.h
+++ b/indra/newview/llquickprefs.h
@@ -27,6 +27,7 @@
 #include "llfloater.h"
 
 class LLSliderCtrl;
+class LLCheckBoxCtrl;
 class LLTextBox;
 
 /**
@@ -76,6 +77,10 @@ private:
     void syncAvatarZOffsetFromPreferenceSetting();
 
     boost::signals2::connection mRegionChangedSlot;
+
+    // OTS over-the-shoulder aim
+    LLCheckBoxCtrl* mOTSEnabledCheck { nullptr };
+    void onOTSEnabledChanged();
 };
 
 #endif // LL_LLQUICKPREFS_H

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -4778,25 +4778,37 @@ class LLViewMouselook : public view_listener_t
 {
     bool handleEvent(const LLSD& userdata)
     {
+        // When OTS is enabled M toggles OTS mode (shoulder cam).
+        // When disabled M toggles normal first-person mouselook.
+        if (gSavedSettings.getBOOL("OTSEnabled"))
+        {
+            if (!gAgentCamera.cameraOTS())
+            {
+                gAgentCamera.changeCameraToOTS();
+            }
+            else
+            {
+                gAgentCamera.changeCameraFromOTS();
+            }
+            return true;
+        }
+
         if (!gAgentCamera.cameraMouselook())
         {
             gAgentCamera.changeCameraToMouselook();
         }
         else
         {
-            // NaCl: Right-click + scroll wheel zoom in mouselook (ported from Firestorm).
-            // If we were zoomed when the user toggles out of mouselook, restore the
-            // normal (pre-zoom) FOV before switching back to the default camera.
+            // NaCl: restore FOV on mouselook exit
             LLVector3 mlFovValues = gSavedSettings.getVector3("_NACL_MLFovValues");
             F32 cameraAngle = gSavedSettings.getF32("CameraAngle");
             if (mlFovValues.mV[VZ] > 0.0f)
             {
-                mlFovValues.mV[VY] = cameraAngle;   // preserve last zoomed FOV
+                mlFovValues.mV[VY] = cameraAngle;
                 mlFovValues.mV[VZ] = 0.0f;
                 gSavedSettings.setVector3("_NACL_MLFovValues", mlFovValues);
-                gSavedSettings.setF32("CameraAngle", mlFovValues.mV[VX]); // restore normal FOV
+                gSavedSettings.setF32("CameraAngle", mlFovValues.mV[VX]);
             }
-            // NaCl End
             gAgentCamera.changeCameraToDefault();
         }
         return true;

--- a/indra/newview/skins/default/xui/en/floater_quick_prefs.xml
+++ b/indra/newview/skins/default/xui/en/floater_quick_prefs.xml
@@ -9,7 +9,7 @@
     can_minimize="true"
     can_close="true"
     can_resize="false"
-    height="96"
+    height="240"
     width="320"
     layout="topleft"
     name="quick_prefs"
@@ -81,5 +81,129 @@
       top_delta="-2"
       name="max_bandwidth"
       tool_tip="Network bandwidth in Kbps (50 – 3000)" />
+
+  <view_border
+      follows="left|right"
+      layout="topleft"
+      left="2"
+      right="-2"
+      top_pad="10"
+      height="2"
+      name="ots_divider" />
+
+  <text
+      type="string"
+      follows="left|top"
+      height="16"
+      layout="topleft"
+      left="5"
+      top_pad="6"
+      width="290"
+      text_color="EmphasisColor"
+      name="OTSLabel">
+    Over-the-Shoulder Cam:
+  </text>
+
+  <check_box
+      control_name="OTSEnabled"
+      follows="left|top"
+      height="16"
+      label="Use Over-The-Shoulder Cam"
+      layout="topleft"
+      left="10"
+      top_pad="4"
+      width="290"
+      name="ots_enabled"
+      tool_tip="When checked, M enters shoulder cam instead of first-person mouselook" />
+
+  <text
+      type="string"
+      follows="left|top"
+      height="16"
+      layout="topleft"
+      left="10"
+      top_pad="6"
+      width="100"
+      name="OTSDistLabel">
+    Distance:
+  </text>
+
+  <slider
+      control_name="OTSCameraDistance"
+      decimal_digits="1"
+      can_edit_text="true"
+      follows="left|right|top"
+      height="16"
+      increment="0.1"
+      initial_value="3.0"
+      max_val="10.0"
+      min_val="1.0"
+      label_width="0"
+      layout="topleft"
+      left="110"
+      right="-10"
+      top_delta="-2"
+      name="ots_distance"
+      tool_tip="Camera distance behind avatar (1 – 10 m)" />
+
+  <text
+      type="string"
+      follows="left|top"
+      height="16"
+      layout="topleft"
+      left="10"
+      top_pad="4"
+      width="100"
+      name="OTSSideLabel">
+    Side offset:
+  </text>
+
+  <slider
+      control_name="OTSCameraSide"
+      decimal_digits="2"
+      can_edit_text="true"
+      follows="left|right|top"
+      height="16"
+      increment="0.05"
+      initial_value="-0.5"
+      max_val="1.0"
+      min_val="-1.0"
+      label_width="0"
+      layout="topleft"
+      left="110"
+      right="-10"
+      top_delta="-2"
+      name="ots_side"
+      tool_tip="Side offset: negative = right shoulder, positive = left shoulder" />
+
+  <text
+      type="string"
+      follows="left|top"
+      height="16"
+      layout="topleft"
+      left="10"
+      top_pad="4"
+      width="100"
+      name="OTSHeightLabel">
+    Height:
+  </text>
+
+  <slider
+      control_name="OTSCameraHeight"
+      decimal_digits="2"
+      can_edit_text="true"
+      follows="left|right|top"
+      height="16"
+      increment="0.05"
+      initial_value="0.5"
+      max_val="2.0"
+      min_val="0.0"
+      label_width="0"
+      layout="topleft"
+      left="110"
+      right="-10"
+      top_delta="-2"
+      name="ots_height"
+      tool_tip="Camera height above avatar root (0 – 2 m)" />
 
 </floater>

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -180,17 +180,6 @@
        name="first_person_avatar_visible"
        top_pad="5"
        width="256" />
-      <check_box
-       control_name="OTSEnabled"
-       follows="left|top"
-       height="20"
-       label="Use Over-The-Shoulder Cam"
-       layout="topleft"
-       left_delta="5"
-       name="ots_enabled"
-       top_pad="5"
-       tool_tip="When checked, pressing M enters over-the-shoulder cam instead of first-person mouselook"
-       width="320" />
       <text
        type="string"
        length="1"

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -161,6 +161,17 @@
    name="first_person_avatar_visible"
    top_pad="5"
    width="256" />
+  <check_box
+   control_name="OTSEnabled"
+   follows="left|top"
+   height="20"
+   label="Use Over-The-Shoulder Cam"
+   layout="topleft"
+   left_delta="5"
+   name="ots_enabled"
+   top_pad="5"
+   tool_tip="When checked, pressing M enters over-the-shoulder cam instead of first-person mouselook"
+   width="320" />
   <text
    type="string"
    length="1"

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -9,328 +9,415 @@
  name="move_panel"
  top="1"
  width="517">
-  <icon
-     follows="left|top"
-     height="18"
-     image_name="Cam_FreeCam_Off"
-     layout="topleft"
-     name="camera_icon"
-     mouse_opaque="false"
-     visible="true"
-     width="18"
-     left="30"
-     top="10"/>
-  <slider
-   can_edit_text="true"
-   control_name="CameraAngle"
-   decimal_digits="2"
-   follows="left|top"
-   height="16"
-   increment="0.025"
-   initial_value="1.57"
-   layout="topleft"
-   label_width="100"
-   label="View angle"
-   left_pad="30"
-   max_val="2.97"
-   min_val="0.17"
-   name="camera_fov"
-   show_text="false"
-   width="240" />
-  <slider
-   can_edit_text="true"
-   control_name="CameraOffsetScale"
-   decimal_digits="2"
-   follows="left|top"
-   height="16"
-   increment="0.025"
-   initial_value="1"
-   layout="topleft"
-   label="Distance"
-   left_delta="0"
-   label_width="100"
-   max_val="3"
-   min_val="0.5"
-   name="camera_offset_scale"
-   show_text="false"
-   width="240"
-   top_pad="5"/>
-  <text
-  follows="left|top"
-  type="string"
-  length="1"
-  height="10"
-  left="80"
-  name="heading2"
-  width="270"
-  top_pad="5">
-    Automatic position for:
-  </text>
-  <check_box
-     control_name="EditCameraMovement"
-     height="20"
-     follows="left|top"
-     label="Build/Edit"
-     layout="topleft"
-     left_delta="30"
-     name="edit_camera_movement"
-     tool_tip="Use automatic camera positioning when entering and exiting edit mode"
-     width="280"
-     top_pad="5" />
-  <check_box
-   control_name="AppearanceCameraMovement"
-   follows="left|top"
-   height="16"
-   label="Appearance"
-   layout="topleft"
-   name="appearance_camera_movement"
-   tool_tip="Use automatic camera positioning while in edit mode"
-   width="242" />
-  <icon
-	 follows="left|top"
-	 height="18"
-	 image_name="Move_Walk_Off"
-   layout="topleft"
-	 name="avatar_icon"
-	 mouse_opaque="false"
-	 visible="true"
-	 width="18"
-   top_pad="10"
-   left="30" />
-  <text
-   follows="left|top"
-   type="string"
-   length="1"
-   height="10"
-   layout="topleft"
-   left="78"
-   name="keyboard_lbl"
-   width="270"
-   top_delta="2">
-    Keyboard:
-  </text>
-  <check_box
-   control_name="ArrowKeysAlwaysMove"
-   follows="left|top"
-   height="20"
-   label="Arrow keys always move me while in chat"
-   layout="topleft"
-   left_delta="5"
-   name="arrow_keys_move_avatar_check"
-   width="237"
-   top_pad="5"/>
-  <check_box
-   control_name="AllowTapTapHoldRun"
-   follows="left|top"
-   height="20"
-   label="Tap-tap-hold to run"
-   layout="topleft"
-   left_delta="0"
-   name="tap_tap_hold_to_run"
-   width="237"
-   top_pad="0"/>
-  <check_box
-   control_name="AutomaticFly"
-   follows="left|top"
-   height="20"
-   label="Hold jump or crouch key to start or stop flying"
-   layout="topleft"
-   left_delta="0"
-   name="automatic_fly"
-   width="237"
-   top_pad="0"/>
-  <text
-   follows="left|top"
-   type="string"
-   length="1"
-   height="10"
-   layout="topleft"
-   left="78"
-   name="mouse_lbl"
-   width="270"
-   top_pad="15">
-    Mouse:
-  </text>
-  <check_box
-   control_name="FirstPersonAvatarVisible"
-   follows="left|top"
-   height="20"
-   label="Show me in Mouselook"
-   layout="topleft"
-   left_delta="5"
-   name="first_person_avatar_visible"
-   top_pad="5"
-   width="256" />
-  <check_box
-   control_name="OTSEnabled"
-   follows="left|top"
-   height="20"
-   label="Use Over-The-Shoulder Cam"
-   layout="topleft"
-   left_delta="5"
-   name="ots_enabled"
-   top_pad="5"
-   tool_tip="When checked, pressing M enters over-the-shoulder cam instead of first-person mouselook"
-   width="320" />
-  <text
-   type="string"
-   length="1"
-   follows="left|top"
-   height="15"
-   layout="topleft"
-   left_delta="3"
-   name=" Mouse Sensitivity"
-   top_pad="10"
-   width="160"
-   wrap="true">
-    Mouselook mouse sensitivity:
-  </text>
-  <slider
-   control_name="MouseSensitivity"
-   follows="left|top"
-   height="15"
-   initial_value="2"
-   layout="topleft"
-   show_text="false"
-   left_pad="0"
-   max_val="15"
-   name="mouse_sensitivity"
-   top_delta="-1"
-   width="115" />
-  <check_box
-   control_name="InvertMouse"
-   height="16"
-   label="Invert"
-   layout="topleft"
-   left_pad="2"
-   name="invert_mouse"
-   top_delta="0"
-   width="128" />
-  <text
-   follows="left|top"
-   type="string"
-   length="1"
-   height="10"
-   layout="topleft"
-   left="86"
-   name="mouse_warp_lbl"
-   width="150"
-   top_pad="20">
-    Mouse Warp:
-  </text>
-  <combo_box
-   control_name="MouseWarpMode"
-   height="23"
-   layout="topleft"
-   left_pad="10"
-   top_delta="-6"
-   name="mouse_warp_combo"
-   tool_tip="Controls warping of the mouse to the center of the screen during alt-zoom and mouse look."
-   width="200">
-    <combo_box.item
-     label="Automatic"
-     name="0"
-     value="0"/>
-    <combo_box.item
-     label="On"
-     name="1"
-     value="1"/>
-    <combo_box.item
-     label="Off"
-     name="2"
-     value="2"/>
-  </combo_box>
-  <text
-   follows="left|top"
-   type="string"
-   length="1"
-   height="10"
-   layout="topleft"
-   left="86"
-   name="single_click_action_lbl"
-   width="150"
-   top_pad="12">
-    Single click on land:
-  </text>
-  <combo_box
-   height="23"
-   layout="topleft"
-   left_pad="10"
-   top_delta="-6"
-   name="single_click_action_combo"
-   width="200">
-    <combo_box.item
-     label="No action"
-     name="0"
-     value="0"/>
-    <combo_box.item
-     label="Move to clicked point"
-     name="1"
-     value="1"/>
-    <combo_box.commit_callback
-     function="Pref.ClickActionChange"/>
-  </combo_box>
-  <text
-   follows="left|top"
-   type="string"
-   length="1"
-   height="10"
-   layout="topleft"
-   left="86"
-   name="double_click_action_lbl"
-   width="150"
-   top_pad="12">
-    Double click on land:
-  </text>
-  <combo_box
-   height="23"
-   layout="topleft"
-   left_pad="10"
-   top_delta="-6"
-   name="double_click_action_combo"
-   width="200">
-    <combo_box.item
-     label="No action"
-     name="0"
-     value="0"/>
-    <combo_box.item
-     label="Move to clicked point"
-     name="1"
-     value="1"/>
-    <combo_box.item
-     label="Teleport to clicked point"
-     name="2"
-     value="2"/>
-    <combo_box.commit_callback
-     function="Pref.ClickActionChange"/>
-  </combo_box>
-  <check_box
-   control_name="EnableCollisionSounds"
-   height="20"
-   label="Play sound on collisions"
-   layout="topleft"
-   left="83"
-   name="sound_on_collisions"
+
+  <tab_container
+   name="move_view_tab_container"
+   enabled="true"
    top_pad="0"
-   width="200" />
-  <check_box
-   control_name="DoubleClickZoomIn"
-   height="20"
-   label="Double click on nearby list to zoom in on avatar"
-   layout="topleft"
-   left="83"
-   name="double_click_zoom_in"
-   top_pad="0"
-   width="200" />
-  <button
-   height="23"
-   label="Other Devices"
-   left="30"
-   name="joystick_setup_button"
-   top="30"
-   width="155">
-    <button.commit_callback
-     function="Floater.Show"
-     parameter="pref_joystick" />
-  </button>
+   follows="left|top|right|bottom"
+   width="517"
+   height="408"
+   left_delta="0"
+   tab_position="top"
+   tab_stop="false">
+
+    <!-- ── Move & View tab (existing content) ─────────────────────────── -->
+    <panel
+     label="Move &amp; View"
+     name="move_view_panel"
+     layout="topleft"
+     follows="top|left">
+
+      <icon
+         follows="left|top"
+         height="18"
+         image_name="Cam_FreeCam_Off"
+         layout="topleft"
+         name="camera_icon"
+         mouse_opaque="false"
+         visible="true"
+         width="18"
+         left="30"
+         top="10"/>
+      <slider
+       can_edit_text="true"
+       control_name="CameraAngle"
+       decimal_digits="2"
+       follows="left|top"
+       height="16"
+       increment="0.025"
+       initial_value="1.57"
+       layout="topleft"
+       label_width="100"
+       label="View angle"
+       left_pad="30"
+       max_val="2.97"
+       min_val="0.17"
+       name="camera_fov"
+       show_text="false"
+       width="240" />
+      <slider
+       can_edit_text="true"
+       control_name="CameraOffsetScale"
+       decimal_digits="2"
+       follows="left|top"
+       height="16"
+       increment="0.025"
+       initial_value="1"
+       layout="topleft"
+       label="Distance"
+       left_delta="0"
+       label_width="100"
+       max_val="3"
+       min_val="0.5"
+       name="camera_offset_scale"
+       show_text="false"
+       width="240"
+       top_pad="5"/>
+      <text
+      follows="left|top"
+      type="string"
+      length="1"
+      height="10"
+      left="80"
+      name="heading2"
+      width="270"
+      top_pad="5">
+        Automatic position for:
+      </text>
+      <check_box
+         control_name="EditCameraMovement"
+         height="20"
+         follows="left|top"
+         label="Build/Edit"
+         layout="topleft"
+         left_delta="30"
+         name="edit_camera_movement"
+         tool_tip="Use automatic camera positioning when entering and exiting edit mode"
+         width="280"
+         top_pad="5" />
+      <check_box
+       control_name="AppearanceCameraMovement"
+       follows="left|top"
+       height="16"
+       label="Appearance"
+       layout="topleft"
+       name="appearance_camera_movement"
+       tool_tip="Use automatic camera positioning while in edit mode"
+       width="242" />
+      <icon
+    	 follows="left|top"
+    	 height="18"
+    	 image_name="Move_Walk_Off"
+       layout="topleft"
+    	 name="avatar_icon"
+    	 mouse_opaque="false"
+    	 visible="true"
+    	 width="18"
+       top_pad="10"
+       left="30" />
+      <text
+       follows="left|top"
+       type="string"
+       length="1"
+       height="10"
+       layout="topleft"
+       left="78"
+       name="keyboard_lbl"
+       width="270"
+       top_delta="2">
+        Keyboard:
+      </text>
+      <check_box
+       control_name="ArrowKeysAlwaysMove"
+       follows="left|top"
+       height="20"
+       label="Arrow keys always move me while in chat"
+       layout="topleft"
+       left_delta="5"
+       name="arrow_keys_move_avatar_check"
+       width="237"
+       top_pad="5"/>
+      <check_box
+       control_name="AllowTapTapHoldRun"
+       follows="left|top"
+       height="20"
+       label="Tap-tap-hold to run"
+       layout="topleft"
+       left_delta="0"
+       name="tap_tap_hold_to_run"
+       width="237"
+       top_pad="0"/>
+      <check_box
+       control_name="AutomaticFly"
+       follows="left|top"
+       height="20"
+       label="Hold jump or crouch key to start or stop flying"
+       layout="topleft"
+       left_delta="0"
+       name="automatic_fly"
+       width="237"
+       top_pad="0"/>
+      <text
+       follows="left|top"
+       type="string"
+       length="1"
+       height="10"
+       layout="topleft"
+       left="78"
+       name="mouse_lbl"
+       width="270"
+       top_pad="15">
+        Mouse:
+      </text>
+      <check_box
+       control_name="FirstPersonAvatarVisible"
+       follows="left|top"
+       height="20"
+       label="Show me in Mouselook"
+       layout="topleft"
+       left_delta="5"
+       name="first_person_avatar_visible"
+       top_pad="5"
+       width="256" />
+      <check_box
+       control_name="OTSEnabled"
+       follows="left|top"
+       height="20"
+       label="Use Over-The-Shoulder Cam"
+       layout="topleft"
+       left_delta="5"
+       name="ots_enabled"
+       top_pad="5"
+       tool_tip="When checked, pressing M enters over-the-shoulder cam instead of first-person mouselook"
+       width="320" />
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="15"
+       layout="topleft"
+       left_delta="3"
+       name=" Mouse Sensitivity"
+       top_pad="10"
+       width="160"
+       wrap="true">
+        Mouselook mouse sensitivity:
+      </text>
+      <slider
+       control_name="MouseSensitivity"
+       follows="left|top"
+       height="15"
+       initial_value="2"
+       layout="topleft"
+       show_text="false"
+       left_pad="0"
+       max_val="15"
+       name="mouse_sensitivity"
+       top_delta="-1"
+       width="115" />
+      <check_box
+       control_name="InvertMouse"
+       height="16"
+       label="Invert"
+       layout="topleft"
+       left_pad="2"
+       name="invert_mouse"
+       top_delta="0"
+       width="128" />
+      <text
+       follows="left|top"
+       type="string"
+       length="1"
+       height="10"
+       layout="topleft"
+       left="86"
+       name="mouse_warp_lbl"
+       width="150"
+       top_pad="20">
+        Mouse Warp:
+      </text>
+      <combo_box
+       control_name="MouseWarpMode"
+       height="23"
+       layout="topleft"
+       left_pad="10"
+       top_delta="-6"
+       name="mouse_warp_combo"
+       tool_tip="Controls warping of the mouse to the center of the screen during alt-zoom and mouse look."
+       width="200">
+        <combo_box.item label="Automatic" name="0" value="0"/>
+        <combo_box.item label="On"         name="1" value="1"/>
+        <combo_box.item label="Off"        name="2" value="2"/>
+      </combo_box>
+      <text
+       follows="left|top"
+       type="string"
+       length="1"
+       height="10"
+       layout="topleft"
+       left="86"
+       name="single_click_action_lbl"
+       width="150"
+       top_pad="12">
+        Single click on land:
+      </text>
+      <combo_box
+       height="23"
+       layout="topleft"
+       left_pad="10"
+       top_delta="-6"
+       name="single_click_action_combo"
+       width="200">
+        <combo_box.item label="No action"              name="0" value="0"/>
+        <combo_box.item label="Move to clicked point"  name="1" value="1"/>
+        <combo_box.commit_callback function="Pref.ClickActionChange"/>
+      </combo_box>
+      <text
+       follows="left|top"
+       type="string"
+       length="1"
+       height="10"
+       layout="topleft"
+       left="86"
+       name="double_click_action_lbl"
+       width="150"
+       top_pad="12">
+        Double click on land:
+      </text>
+      <combo_box
+       height="23"
+       layout="topleft"
+       left_pad="10"
+       top_delta="-6"
+       name="double_click_action_combo"
+       width="200">
+        <combo_box.item label="No action"                   name="0" value="0"/>
+        <combo_box.item label="Move to clicked point"       name="1" value="1"/>
+        <combo_box.item label="Teleport to clicked point"   name="2" value="2"/>
+        <combo_box.commit_callback function="Pref.ClickActionChange"/>
+      </combo_box>
+      <check_box
+       control_name="EnableCollisionSounds"
+       height="20"
+       label="Play sound on collisions"
+       layout="topleft"
+       left="83"
+       name="sound_on_collisions"
+       top_pad="0"
+       width="200" />
+      <check_box
+       control_name="DoubleClickZoomIn"
+       height="20"
+       label="Double click on nearby list to zoom in on avatar"
+       layout="topleft"
+       left="83"
+       name="double_click_zoom_in"
+       top_pad="0"
+       width="200" />
+      <button
+       height="23"
+       label="Other Devices"
+       left="30"
+       name="joystick_setup_button"
+       top="30"
+       width="155">
+        <button.commit_callback function="Floater.Show" parameter="pref_joystick" />
+      </button>
+
+    </panel>
+
+    <!-- ── Over-The-Shoulder tab ──────────────────────────────────────── -->
+    <panel
+     label="Over-The-Shoulder"
+     name="ots_panel"
+     layout="topleft"
+     follows="top|left">
+
+      <text
+       type="string"
+       follows="left|top"
+       font="SansSerifSmallBold"
+       height="20"
+       layout="topleft"
+       left="10"
+       name="ots_enable_header"
+       top="10"
+       width="490">
+        Over-the-Shoulder Camera
+      </text>
+
+      <check_box
+       control_name="OTSEnabled"
+       follows="left|top"
+       height="20"
+       label="Use Over-The-Shoulder Cam"
+       layout="topleft"
+       left="15"
+       name="ots_enabled_pref"
+       top_pad="5"
+       tool_tip="When checked, pressing M enters over-the-shoulder cam instead of first-person mouselook"
+       width="350" />
+
+      <text
+       type="string"
+       follows="left|top"
+       font="SansSerifSmallBold"
+       height="20"
+       layout="topleft"
+       left="10"
+       name="ots_pos_header"
+       top_pad="12"
+       width="490">
+        Camera Position
+      </text>
+
+      <text type="string" follows="left|top" height="16" layout="topleft"
+       left="15" top_pad="6" width="130" name="dist_label">Distance:</text>
+      <slider
+       control_name="OTSCameraDistance"
+       decimal_digits="1" can_edit_text="true"
+       follows="left|right|top" height="16"
+       increment="0.1" initial_value="3.0" max_val="10.0" min_val="1.0"
+       label_width="0" layout="topleft" left="150" right="-10" top_delta="-2"
+       name="ots_distance"
+       tool_tip="Camera distance behind avatar (1 – 10 m)" />
+
+      <text type="string" follows="left|top" height="16" layout="topleft"
+       left="15" top_pad="6" width="130" name="side_label">Side offset:</text>
+      <slider
+       control_name="OTSCameraSide"
+       decimal_digits="2" can_edit_text="true"
+       follows="left|right|top" height="16"
+       increment="0.05" initial_value="-0.5" max_val="1.0" min_val="-1.0"
+       label_width="0" layout="topleft" left="150" right="-10" top_delta="-2"
+       name="ots_side"
+       tool_tip="Side offset: negative = right shoulder, positive = left shoulder" />
+
+      <text type="string" follows="left|top" height="16" layout="topleft"
+       left="15" top_pad="6" width="130" name="height_label">Height:</text>
+      <slider
+       control_name="OTSCameraHeight"
+       decimal_digits="2" can_edit_text="true"
+       follows="left|right|top" height="16"
+       increment="0.05" initial_value="0.5" max_val="2.0" min_val="0.0"
+       label_width="0" layout="topleft" left="150" right="-10" top_delta="-2"
+       name="ots_height"
+       tool_tip="Camera height above avatar root (0 – 2 m)" />
+
+      <text type="string" follows="left|top" height="16" layout="topleft"
+       left="15" top_pad="6" width="130" name="focus_label">Focus distance:</text>
+      <slider
+       control_name="OTSFocusDistance"
+       decimal_digits="1" can_edit_text="true"
+       follows="left|right|top" height="16"
+       increment="0.5" initial_value="10.0" max_val="30.0" min_val="2.0"
+       label_width="0" layout="topleft" left="150" right="-10" top_delta="-2"
+       name="ots_focus_dist"
+       tool_tip="Focus point distance along camera forward axis (2 – 30 m)" />
+
+    </panel>
+
+  </tab_container>
+
 </panel>


### PR DESCRIPTION
# Added: 
- `CAMERA_MODE_OTS` which is an entirely new camera function that sits alongside `CAMERA_MODE_MOUSELOOK` and `CAMERA_MODE_THIRD_PERSON` this leaves the existing camera modes untouched.

Five new settings:
- `OTSEnabled` (Overriding first person Mouselook)
- Camera Offset settings `OTSCameraDistance`, `OTSCameraSide`, `OTSCameraHeight`, and `OTSFocusDistance` all stored in `settings.xml` and having sliders for their various floats in the new tab I have added in Preferences under Move & View, as well as the QuickPrefs UI element

# Recycled/reused:
- The entire Mouselook Input system

This was done specifically because of how deeply integrated the mouselook system and reimplementing those features from scratch would have taken even more time and introduced a plethora of bugs along the way. 

- [x] -TODO: 
Replicate how traditional Mouselook respect the ZoomTime Float to smoothly transition into OTS mode.