### PR TITLE
Add Teleport Overrides for combat people

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -4741,6 +4741,28 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>KeepCameraOnLocalTeleport</key>
+    <map>
+      <key>Comment</key>
+      <string>Do not reset the camera position or mode when teleporting within the same region.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
+    <key>DisableTeleportScreens</key>
+    <map>
+      <key>Comment</key>
+      <string>Do not show the fullscreen teleport progress/black screen during teleports.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>MiniMapAutoCenter</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -280,6 +280,12 @@ static void update_tp_display(bool minimized)
     F32 teleport_save_time = TELEPORT_EXPIRY + TELEPORT_EXPIRY_PER_ATTACHMENT * attach_count;
     F32 teleport_elapsed = gTeleportDisplayTimer.getElapsedTimeF32();
     F32 teleport_percent = teleport_elapsed * (100.f / teleport_save_time);
+
+    // Reuse the minimized-window path to suppress the teleport progress screen.
+    if (gSavedSettings.getBOOL("DisableTeleportScreens"))
+    {
+        minimized = true;
+    }
     if (gAgent.getTeleportState() != LLAgent::TELEPORT_START && teleport_percent > 100.f)
     {
         // Give up.  Don't keep the UI locked forever.

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -6120,11 +6120,18 @@ void process_teleport_local(LLMessageSystem *msg,void**)
     }
 
     gAgent.setPositionAgent(pos);
-    gAgentCamera.slamLookAt(look_at);
+
+    bool keep_camera_local_tp = gSavedSettings.getBOOL("KeepCameraOnLocalTeleport");
+
+    if (!keep_camera_local_tp)
+    {
+        gAgentCamera.slamLookAt(look_at);
+    }
 
     if ( !(gAgent.getTeleportKeepsLookAt() && LLViewerJoystick::getInstance()->getOverrideCamera()) )
     {
-        gAgentCamera.resetView(true, true);
+        // resetView still runs (cleanup); the false args just leave the camera alone.
+        gAgentCamera.resetView(!keep_camera_local_tp, !keep_camera_local_tp);
     }
 
     // send camera update to new region

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -407,6 +407,52 @@
 
     </panel>
 
+    <!-- ── Teleports tab ──────────────────────────────────────────────── -->
+    <panel
+     label="Teleports"
+     name="teleports_panel"
+     layout="topleft"
+     follows="top|left">
+
+      <text
+       type="string"
+       follows="left|top"
+       font="SansSerifSmallBold"
+       height="20"
+       layout="topleft"
+       left="10"
+       name="teleport_header"
+       top="10"
+       width="490">
+        Teleport Options
+      </text>
+
+      <check_box
+       control_name="KeepCameraOnLocalTeleport"
+       follows="left|top"
+       height="20"
+       label="Keep camera position on local teleport"
+       layout="topleft"
+       left="15"
+       name="keep_camera_on_local_teleport"
+       top_pad="8"
+       tool_tip="When teleporting within the same region, do not reset the camera position or mode (stays in mouselook/over-the-shoulder)"
+       width="450" />
+
+      <check_box
+       control_name="DisableTeleportScreens"
+       follows="left|top"
+       height="20"
+       label="Disable teleport progress screen"
+       layout="topleft"
+       left="15"
+       name="disable_teleport_screens"
+       top_pad="6"
+       tool_tip="Do not show the fullscreen progress/black screen during teleports"
+       width="450" />
+
+    </panel>
+
   </tab_container>
 
 </panel>


### PR DESCRIPTION
This does exactly what the title says. Just enables you to disable the teleport progress screen and prevent the camera from resetting on teleport/death. 

Adds Teleports tab in Move & View to keep the other tabs clean. 

I reused the minimized window path since we get it for free the voiding the teleport progress screen. 

Meant to commit these last night but wanted to separate the features into different PRs for cleanliness. 