### PR TITLE
Fix arm64 builds failing with ENABLE_MEDIA_PLUGINS=OFF

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -2202,8 +2202,14 @@ endif ()
 
 if (ENABLE_MEDIA_PLUGINS)
    target_link_libraries(${VIEWER_BINARY_NAME} ll::libvlc )
+   # Tell the viewer source which media-library version headers are
+   # actually available in this build, so version reporting in
+   # llappviewer.cpp is gated on the build configuration rather than on
+   # a CPU/compiler macro. Mirrors the link availability above exactly.
+   target_compile_definitions(${VIEWER_BINARY_NAME} PRIVATE LL_VLC=1)
    if (DARWIN OR LINUX)
       target_link_libraries(${VIEWER_BINARY_NAME} ll::cef )
+      target_compile_definitions(${VIEWER_BINARY_NAME} PRIVATE LL_CEF=1)
    endif ()
 endif ()
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -136,10 +136,12 @@
 #include "stringize.h"
 #include "llcoros.h"
 #include "llexception.h"
-#if !_M_ARM64 // !LL_LINUX
+#if defined(LL_CEF)
 #include "cef/dullahan_version.h"
+#endif
+#if defined(LL_VLC)
 #include "vlc/libvlc_version.h"
-#endif // LL_LINUX
+#endif
 
 #if LL_DARWIN
 #if LL_SDL
@@ -3517,7 +3519,7 @@ LLSD LLAppViewer::getViewerInfo() const
         info["VOICE_VERSION"] = LLTrans::getString("NotConnected");
     }
 
-#if !_M_ARM64 // !LL_LINUX
+#if defined(LL_CEF)
     std::ostringstream cef_ver_codec;
     cef_ver_codec << "Dullahan: ";
     cef_ver_codec << DULLAHAN_VERSION_MAJOR;
@@ -3547,7 +3549,7 @@ LLSD LLAppViewer::getViewerInfo() const
     info["LIBCEF_VERSION"] = "Undefined";
 #endif
 
-#if !_M_ARM64 // !LL_LINUX
+#if defined(LL_VLC)
     std::ostringstream vlc_ver_codec;
     vlc_ver_codec << LIBVLC_VERSION_MAJOR;
     vlc_ver_codec << ".";


### PR DESCRIPTION
The version-reporting blocks in `llappviewer.cpp` that include `cef/dullahan_version.h` and `vlc/libvlc_version.h` were guarded with `#if !_M_ARM64`. `_M_ARM64` is a Microsoft Visual C++ predefined macro that is only defined when MSVC is targeting ARM64 — it is never defined by Clang or GCC on any platform or architecture.

On macOS (Clang), `_M_ARM64` is always undefined, so these blocks compiled unconditionally and failed with:

```
fatal error: 'cef/dullahan_version.h' file not found
```

whenever the CEF/VLC headers were not on the include path — including any build with `ENABLE_MEDIA_PLUGINS=OFF`.

The upstream viewer uses `#if !LL_LINUX` for this guard, which is a correct cross-platform macro. I put in a more direct approach: CMake now emits `LL_CEF` and `LL_VLC` compile definitions that mirror the actual media library availability in the build (`ll::cef` is linked on Darwin and Linux; `ll::libvlc` is linked whenever media plugins are enabled). The source guards are updated to use these definitions, so the version-reporting code compiles only when the headers are genuinely available, on any platform and compiler.
