### PR TITLE
Add Estate Eject and Estate Ban to avatar context menus

### DIFF
--- a/indra/newview/llavataractions.cpp
+++ b/indra/newview/llavataractions.cpp
@@ -34,6 +34,7 @@
 #include "llnotifications.h"
 #include "llnotificationsutil.h"
 #include "roles_constants.h"    // for GP_MEMBER_INVITE
+#include "llregionflags.h"      // for ESTATE_ACCESS_BANNED_AGENT_ADD
 
 #include "llagent.h"
 #include "llappviewer.h"        // for gLastVersionChannel
@@ -622,6 +623,34 @@ void LLAvatarActions::ejectAvatar(const LLUUID& id, bool ban_enabled)
             LLNotificationsUtil::add("EjectAvatarNoBan", LLSD(), payload, handleEjectAvatar);
         }
     }
+}
+
+// static
+void LLAvatarActions::estateKickAvatar(const LLUUID& id)
+{
+    LLAvatarName av_name;
+    LLSD payload;
+    payload["avatar_id"] = id;
+    LLSD args;
+    if (LLAvatarNameCache::get(id, &av_name))
+    {
+        args["EVIL_USER"] = av_name.getCompleteName();
+    }
+    LLNotificationsUtil::add("EstateKickUser", args, payload, handleEstateKickAvatar);
+}
+
+// static
+void LLAvatarActions::estateBanAvatar(const LLUUID& id)
+{
+    LLAvatarName av_name;
+    LLSD payload;
+    payload["avatar_id"] = id;
+    LLSD args;
+    if (LLAvatarNameCache::get(id, &av_name))
+    {
+        args["AVATAR_NAME"] = av_name.getCompleteName();
+    }
+    LLNotificationsUtil::add("EstateBanUser", args, payload, handleEstateBanAvatar);
 }
 
 // static
@@ -1420,6 +1449,62 @@ bool LLAvatarActions::handleEjectAvatar(const LLSD& notification, const LLSD& re
         msg->nextBlock("Data");
         msg->addUUID("TargetID", avatar_id );
         msg->addU32("Flags", flags );
+        gAgent.sendReliableMessage();
+    }
+    return false;
+}
+
+bool LLAvatarActions::handleEstateKickAvatar(const LLSD& notification, const LLSD& response)
+{
+    S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
+    if (option == 0)
+    {
+        LLUUID avatar_id = notification["payload"]["avatar_id"].asUUID();
+        LLMessageSystem* msg = gMessageSystem;
+        msg->newMessage("EstateOwnerMessage");
+        msg->nextBlockFast(_PREHASH_AgentData);
+        msg->addUUIDFast(_PREHASH_AgentID, gAgent.getID());
+        msg->addUUIDFast(_PREHASH_SessionID, gAgent.getSessionID());
+        msg->addUUIDFast(_PREHASH_TransactionID, LLUUID::null);
+        msg->nextBlock("MethodData");
+        msg->addString("Method", "kickestate");
+        msg->addUUID("Invoice", LLUUID::generateNewID());
+        msg->nextBlock("ParamList");
+        msg->addString("Parameter", avatar_id.asString());
+        gAgent.sendReliableMessage();
+    }
+    return false;
+}
+
+bool LLAvatarActions::handleEstateBanAvatar(const LLSD& notification, const LLSD& response)
+{
+    S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
+    if (option == 0)
+    {
+        LLUUID avatar_id = notification["payload"]["avatar_id"].asUUID();
+        LLMessageSystem* msg = gMessageSystem;
+        msg->newMessage("EstateOwnerMessage");
+        msg->nextBlockFast(_PREHASH_AgentData);
+        msg->addUUIDFast(_PREHASH_AgentID, gAgent.getID());
+        msg->addUUIDFast(_PREHASH_SessionID, gAgent.getSessionID());
+        msg->addUUIDFast(_PREHASH_TransactionID, LLUUID::null);
+        msg->nextBlock("MethodData");
+        msg->addString("Method", "estateaccessdelta");
+        msg->addUUID("Invoice", LLUUID::generateNewID());
+
+        std::string buf;
+        gAgent.getID().toString(buf);
+        msg->nextBlock("ParamList");
+        msg->addString("Parameter", buf);
+
+        buf = llformat("%u", (U32)ESTATE_ACCESS_BANNED_AGENT_ADD);
+        msg->nextBlock("ParamList");
+        msg->addString("Parameter", buf);
+
+        avatar_id.toString(buf);
+        msg->nextBlock("ParamList");
+        msg->addString("Parameter", buf);
+
         gAgent.sendReliableMessage();
     }
     return false;

--- a/indra/newview/llavataractions.h
+++ b/indra/newview/llavataractions.h
@@ -192,6 +192,10 @@ public:
     static void freezeAvatar(const LLUUID& id);
 
     static void ejectAvatar(const LLUUID& id, bool ban_enabled = false);
+
+    static void estateKickAvatar(const LLUUID& id);
+
+    static void estateBanAvatar(const LLUUID& id);
     /**
      * Kick avatar off grid
      */
@@ -263,6 +267,8 @@ private:
     static bool handlePay(const LLSD& notification, const LLSD& response, LLUUID avatar_id);
     static bool handleFreezeAvatar(const LLSD& notification, const LLSD& response);
     static bool handleEjectAvatar(const LLSD& notification, const LLSD& response);
+    static bool handleEstateKickAvatar(const LLSD& notification, const LLSD& response);
+    static bool handleEstateBanAvatar(const LLSD& notification, const LLSD& response);
     static bool handleKick(const LLSD& notification, const LLSD& response);
     static bool handleFreeze(const LLSD& notification, const LLSD& response);
     static bool handleUnfreeze(const LLSD& notification, const LLSD& response);

--- a/indra/newview/llpanelpeoplemenus.cpp
+++ b/indra/newview/llpanelpeoplemenus.cpp
@@ -84,11 +84,14 @@ LLContextMenu* PeopleContextMenu::createMenu()
         registrar.add("Avatar.Calllog",         boost::bind(&LLAvatarActions::viewChatHistory,          id));
         registrar.add("Avatar.Freeze",          boost::bind(&LLAvatarActions::freezeAvatar,                 id));
         registrar.add("Avatar.Eject",           boost::bind(&PeopleContextMenu::eject,                  this));
+        registrar.add("Avatar.EstateKick",      boost::bind(&LLAvatarActions::estateKickAvatar,             id));
+        registrar.add("Avatar.EstateBan",       boost::bind(&LLAvatarActions::estateBanAvatar,              id));
 
 
         enable_registrar.add("Avatar.EnableItem", boost::bind(&PeopleContextMenu::enableContextMenuItem, this, _2));
         enable_registrar.add("Avatar.CheckItem",  boost::bind(&PeopleContextMenu::checkContextMenuItem, this, _2));
         enable_registrar.add("Avatar.EnableFreezeEject", boost::bind(&PeopleContextMenu::enableFreezeEject, this, _2));
+        enable_registrar.add("Avatar.EnableEstateEjectBan", boost::bind(&PeopleContextMenu::enableEstateEjectBan, this, _2));
 
         // create the context menu from the XUI
         menu = createFromFile("menu_people_nearby.xml");
@@ -318,6 +321,17 @@ bool PeopleContextMenu::enableFreezeEject(const LLSD& userdata)
     return new_value;
 }
 
+bool PeopleContextMenu::enableEstateEjectBan(const LLSD& userdata)
+{
+    if (gAgent.getID() == mUUIDs.front() || mUUIDs.size() != 1)
+        return false;
+
+    LLViewerRegion* region = gAgent.getRegion();
+    if (!region) return false;
+    if (gAgent.isGodlike()) return true;
+    return region->getOwner() == gAgent.getID() || region->isEstateManager();
+}
+
 void PeopleContextMenu::requestTeleport()
 {
     // boost::bind cannot recognize overloaded method LLAvatarActions::teleportRequest(),
@@ -419,6 +433,8 @@ void NearbyPeopleContextMenu::buildContextMenu(class LLMenuGL& menu, U32 flags)
         items.push_back(std::string("block_unblock"));
         items.push_back(std::string("freeze"));
         items.push_back(std::string("eject"));
+        items.push_back(std::string("estate_eject"));
+        items.push_back(std::string("estate_ban"));
     }
 
     hide_context_entries(menu, items, disabled_items);

--- a/indra/newview/llpanelpeoplemenus.h
+++ b/indra/newview/llpanelpeoplemenus.h
@@ -47,6 +47,7 @@ private:
     bool enableContextMenuItem(const LLSD& userdata);
     bool checkContextMenuItem(const LLSD& userdata);
     bool enableFreezeEject(const LLSD& userdata);
+    bool enableEstateEjectBan(const LLSD& userdata);
     void offerTeleport();
     void eject();
     void startConference();

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -4065,6 +4065,44 @@ void handle_avatar_eject(const LLSD& avatar_id)
         }
 }
 
+void handle_avatar_estate_kick(const LLSD& avatar_id)
+{
+    LLUUID id = avatar_id.asUUID();
+    if (id.isNull())
+    {
+        LLVOAvatar* avatar = find_avatar_from_object(
+            LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
+        if (avatar) id = avatar->getID();
+    }
+    if (id.notNull())
+    {
+        LLAvatarActions::estateKickAvatar(id);
+    }
+}
+
+void handle_avatar_estate_ban(const LLSD& avatar_id)
+{
+    LLUUID id = avatar_id.asUUID();
+    if (id.isNull())
+    {
+        LLVOAvatar* avatar = find_avatar_from_object(
+            LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
+        if (avatar) id = avatar->getID();
+    }
+    if (id.notNull())
+    {
+        LLAvatarActions::estateBanAvatar(id);
+    }
+}
+
+bool enable_estate_eject_ban(const LLSD& avatar_id)
+{
+    LLViewerRegion* region = gAgent.getRegion();
+    if (!region) return false;
+    if (gAgent.isGodlike()) return true;
+    return region->getOwner() == gAgent.getID() || region->isEstateManager();
+}
+
 bool my_profile_visible()
 {
     LLFloater* floaterp = LLAvatarActions::getProfileFloater(gAgentID);
@@ -10358,6 +10396,9 @@ void initialize_menus()
     view_listener_t::addMenu(new LLAvatarVisibleDebug(), "Avatar.VisibleDebug");
     view_listener_t::addMenu(new LLAvatarInviteToGroup(), "Avatar.InviteToGroup");
     commit.add("Avatar.Eject", boost::bind(&handle_avatar_eject, LLSD()));
+    commit.add("Avatar.EstateKick", boost::bind(&handle_avatar_estate_kick, _2));
+    commit.add("Avatar.EstateBan", boost::bind(&handle_avatar_estate_ban, _2));
+    enable.add("Avatar.EnableEstateEjectBan", boost::bind(&enable_estate_eject_ban, _2));
     commit.add("Avatar.ShowInspector", boost::bind(&handle_avatar_show_inspector));
     view_listener_t::addMenu(new LLAvatarSendIM(), "Avatar.SendIM");
     view_listener_t::addMenu(new LLAvatarCall(), "Avatar.Call");

--- a/indra/newview/skins/default/xui/en/menu_avatar_other.xml
+++ b/indra/newview/skins/default/xui/en/menu_avatar_other.xml
@@ -90,6 +90,22 @@
              function="Avatar.EnableFreezeEject"/>
         </menu_item_call>
         <menu_item_call
+         label="Estate Eject"
+         name="EstateEject...">
+            <menu_item_call.on_click
+             function="Avatar.EstateKick" />
+            <menu_item_call.on_visible
+             function="Avatar.EnableEstateEjectBan"/>
+        </menu_item_call>
+        <menu_item_call
+         label="Estate Ban"
+         name="EstateBan...">
+            <menu_item_call.on_click
+             function="Avatar.EstateBan" />
+            <menu_item_call.on_visible
+             function="Avatar.EnableEstateEjectBan"/>
+        </menu_item_call>
+        <menu_item_call
          label="Debug Textures"
          name="Debug...">
             <menu_item_call.on_click

--- a/indra/newview/skins/default/xui/en/menu_people_nearby.xml
+++ b/indra/newview/skins/default/xui/en/menu_people_nearby.xml
@@ -169,4 +169,20 @@
         <menu_item_call.on_visible
          function="Avatar.EnableFreezeEject"/>
     </menu_item_call>
+    <menu_item_call
+         label="Estate Eject"
+         name="estate_eject">
+        <menu_item_call.on_click
+         function="Avatar.EstateKick" />
+        <menu_item_call.on_visible
+         function="Avatar.EnableEstateEjectBan"/>
+    </menu_item_call>
+    <menu_item_call
+         label="Estate Ban"
+         name="estate_ban">
+        <menu_item_call.on_click
+         function="Avatar.EstateBan" />
+        <menu_item_call.on_visible
+         function="Avatar.EnableEstateEjectBan"/>
+    </menu_item_call>
 </context_menu>

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -5404,6 +5404,18 @@ Kick [EVIL_USER] from this estate?
 
   <notification
    icon="alertmodal.tga"
+   name="EstateBanUser"
+   type="alertmodal">
+Ban [AVATAR_NAME] from this estate?
+    <tag>confirm</tag>
+    <usetemplate
+     name="okcancelbuttons"
+     notext="Cancel"
+     yestext="Ban"/>
+  </notification>
+
+  <notification
+   icon="alertmodal.tga"
    name="EstateChangeCovenant"
    type="alertmodal">
 Are you sure you want to change the Estate Covenant?


### PR DESCRIPTION
I added flags to check to see if you are an Estate Owner/Manager

If either of those are true you will have additional context options to to Estate Kick or Estate ban when right clicking the nameplate or avatar name in NearBy

I have no idea why this isn't in the default viewer. Having to open the entire region panel and manually search/paste them in is insane lol.